### PR TITLE
Document Analyses response

### DIFF
--- a/docs/source/main/building-security-tools-on-mythx.rst
+++ b/docs/source/main/building-security-tools-on-mythx.rst
@@ -302,6 +302,27 @@ The output contains a list of issues with title, short description and long desc
 - The `meta` field contains meta information about the analysis run.
 
 
+It is recommended that users submit both bytecode and source code to obtain a full analysis, but in the case that no source code is provided, ie: only the submitting the deployed bytecode. MythX will return the following result:
+
+.. code-block:: json
+
+  [
+    {
+      "issues": [
+        {
+          ...
+          sourceType: 'raw-bytecode',
+          sourceFormat: 'evm-byzantium-bytecode',
+          sourceList:
+            [ '0x98d243270da47b324377a628b45e42110ba7520280b8e13ac94aad07501fbb2e' ],
+          meta: { coveredInstructions: 111, coveredPaths: 5 },
+        },
+        ...
+      ]
+    }
+  ]
+
+In this instance, `sourceList: [0x98...]` refers to the Keccak256 hash of the runtime bytecode within which the issue was found.
 
 API Details
 -----------

--- a/docs/source/main/building-security-tools-on-mythx.rst
+++ b/docs/source/main/building-security-tools-on-mythx.rst
@@ -293,6 +293,10 @@ The output contains a list of issues with title, short description and long desc
 
 - The `swcID` field contains a reference to the
   `Smart Contract Weakness Classification Registry <https://smartcontractsecurity.github.io/SWC-registry/>`_.
+- The `description` field describes the found issue in two entries.
+
+  - `head` is the summary of the found issue.
+  - `tail` contains the details on what causes the issue well as any possible remediation.
 - The `locations` list contain one or more solc-style `sourceMap` entries that contain bytecode offsets into the provided 
   source code files. This source mapping format is described in the `solc documentation <https://solidity.readthedocs.io/en/latest/miscellaneous.html#source-mappings>`_. The notation `s:l:f` where  `s` is the byte-offset to the start of the range in the source file, `l` is the length of the source range in bytes and `f` is the index of the source code file in the `sourceList`.
 - The `meta` field contains meta information about the analysis run.

--- a/docs/source/main/building-security-tools-on-mythx.rst
+++ b/docs/source/main/building-security-tools-on-mythx.rst
@@ -302,27 +302,28 @@ The output contains a list of issues with title, short description and long desc
 - The `meta` field contains meta information about the analysis run.
 
 
-It is recommended that users submit both bytecode and source code to obtain a full analysis, but in the case that no source code is provided, ie: only the submitting the deployed bytecode. MythX will return the following result:
+We recommend that users submit both bytecode and source code to obtain a full analysis. If only the creation bytecode is given, and not the source code, MythX will return a result like the folllowing:
 
 .. code-block:: json
 
   [
     {
       "issues": [
-        {
-          ...
-          sourceType: 'raw-bytecode',
-          sourceFormat: 'evm-byzantium-bytecode',
-          sourceList:
-            [ '0x98d243270da47b324377a628b45e42110ba7520280b8e13ac94aad07501fbb2e' ],
-          meta: { coveredInstructions: 111, coveredPaths: 5 },
-        },
-        ...
-      ]
+        (...)
+      ],
+      "sourceType": "raw-bytecode",
+      "sourceFormat": "evm-byzantium-bytecode",
+      "sourceList": [
+        "0x98d243270da47b324377a628b45e42110ba7520280b8e13ac94aad07501fbb2e"
+      ],
+      "meta": {
+        "coveredInstructions": 111,
+        "coveredPaths": 5
+      },
     }
   ]
 
-In this instance, `sourceList: [0x98...]` refers to the Keccak256 hash of the runtime bytecode within which the issue was found.
+In this instance, ``sourceList: [0x98...]`` refers to the Keccak256 hash of the runtime bytecode within which the issue(s) weres found.
 
 API Details
 -----------


### PR DESCRIPTION
Resolves:
https://diligence.atlassian.net/browse/BAH-90
Documented SWC issue description that the `head` field acts a brief overview of the issue found and the details/remediation is contained in `tail`

https://diligence.atlassian.net/browse/MAES-120
Clarified that for analyses with only bytecode submitted the result's `sourceList` refers to the hash of the runtime bytecode.