### PR TITLE
Updating command syntax for Truffle plugin

### DIFF
--- a/docs/source/tooling/truffle.rst
+++ b/docs/source/tooling/truffle.rst
@@ -56,8 +56,8 @@ If you install MythX for Truffle in this manner, **you will in addition need to 
 
    };
 
-Running
--------
+Usage
+-----
 
 To run MythX for Truffle, run the following command in the root of your configured Truffle project::
 
@@ -65,12 +65,23 @@ To run MythX for Truffle, run the following command in the root of your configur
 
 .. note:: The project must compile successfully in order for the plugin to run. If the project hasn't been compiled yet, MythX for Truffle will try to compile it first.
 
-By default, all contracts in the project will be analyzed. To analyze only some of the contracts, append them to the command::
+By default, all contracts in the project will be analyzed. To analyze only some of the contracts, use the following syntax::
 
-  truffle run verify MyContract MyContract2
+  truffle run verify contract.sol
 
-The above command will analyze only the ``MyContract`` and ``MyContract2`` contracts.
+This will analyse all the contracts found in the file ``contract.sol``.
 
+You can also analyze a specific contract::
+
+  truffle run verify contract.sol:MyContract
+
+This will analyse the contract named ``MyContract`` found in the file ``contract.sol``.
+
+.. warning::
+
+   The following syntax has been deprecated and should not be used::
+
+     truffle run verify MyContract
 
 Command options
 ---------------

--- a/docs/source/tooling/truffle.rst
+++ b/docs/source/tooling/truffle.rst
@@ -40,7 +40,7 @@ Global installation
 
 Install the plugin globally so that it is accessible to all projects::
 
-  npm install truffle-security
+  npm install -g truffle-security
 
 If you install MythX for Truffle in this manner, **you will in addition need to edit each project's configuration file** (``truffle-config.js``) to add the necessary plugin:
 
@@ -59,23 +59,44 @@ If you install MythX for Truffle in this manner, **you will in addition need to 
 Usage
 -----
 
+Analyzing an entire project
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 To run MythX for Truffle, run the following command in the root of your configured Truffle project::
 
   truffle run verify
 
 .. note:: The project must compile successfully in order for the plugin to run. If the project hasn't been compiled yet, MythX for Truffle will try to compile it first.
 
-By default, all contracts in the project will be analyzed. To analyze only some of the contracts, use the following syntax::
+Analyzing whole contract files
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, all contracts in all contract files in the project will be analyzed. To analyze only a single contract file, use the following syntax::
 
   truffle run verify contract.sol
 
-This will analyse all the contracts found in the file ``contract.sol``.
+This will analyze all the contracts found in the file ``contract.sol``.
+
+Multiple contract files can be specified here as well::
+
+  truffle run verify contract1.sol contract2.sol
+
+All contracts inside both ``contract1.sol`` and ``contract2.sol`` will be analyzed.
+
+Analyzing specific contracts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can also analyze a specific contract::
 
   truffle run verify contract.sol:MyContract
 
-This will analyse the contract named ``MyContract`` found in the file ``contract.sol``.
+This will analyze the contract named ``MyContract`` found in the file ``contract.sol``.
+
+Multiple contracts can be specified here too. For example::
+
+  truffle run verify contract1.sol:MyContract1 contract2.sol:MyContract2
+
+This will analyze both ``MyContract1`` and ``MyContract2``, which are found in the ``contract1.sol`` and ``contract2.sol`` files respectively.
 
 .. warning::
 
@@ -114,7 +135,7 @@ Outputs the report in the given `es-lint <https://eslint.org/docs/user-guide/for
 ``--timeout <S>``
 ^^^^^^^^^^^^^^^^^
 
-Limits MythX analyses time to ``<S>`` seconds. The default is 120 seconds.
+Limits MythX analyzes time to ``<S>`` seconds. The default is 120 seconds.
 
 ``--limit <N>``
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
In v1.5.0, there is new syntax:

> Instead of `truffle run verify ContractName`, use `truffle run verify contract.sol:ContractName` or `truffle run verify contract.sol`. This is because there are cases with contracts with the same name, and it is just less clear in general. The old method still works for now, but is deprecated, and a warning will be displayed. 